### PR TITLE
Fix MaxAllCPU signature drift in cratedb/questdb generators

### DIFF
--- a/cmd/tsbs_generate_queries/databases/cratedb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops.go
@@ -44,8 +44,8 @@ func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 // Queries:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	selectClauses := d.getSelectAggClauses("max", devops.GetAllCPUMetrics())
 	hosts, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
@@ -85,7 +85,7 @@ func TestDevopsMaxAllCPUQuery(t *testing.T) {
 		)}
 
 	got := &query.CrateDB{}
-	d.MaxAllCPU(got, 2)
+	d.MaxAllCPU(got, 2, devops.MaxAllDuration)
 
 	if !reflect.DeepEqual(want.SqlQuery, got.SqlQuery) {
 		t.Errorf("incorrect sql query:\ngot: %s\n want:\n %s",

--- a/cmd/tsbs_generate_queries/databases/questdb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/questdb/devops.go
@@ -42,8 +42,8 @@ func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 // Queries:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	selectClauses := d.getSelectAggClauses("max", devops.GetAllCPUMetrics())
 	hosts, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/questdb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/questdb/devops_test.go
@@ -129,7 +129,7 @@ func TestMaxAllCPU(t *testing.T) {
 
 	testFunc := func(d *Devops, c testCase) query.Query {
 		q := d.GenerateEmptyQuery()
-		d.MaxAllCPU(q, c.input)
+		d.MaxAllCPU(q, c.input, devops.MaxAllDuration)
 		return q
 	}
 

--- a/cmd/tsbs_run_queries_cratedb/main.go
+++ b/cmd/tsbs_run_queries_cratedb/main.go
@@ -135,7 +135,13 @@ func (p *processor) ProcessQuery(q query.Query, isWarm bool) ([]*query.Stat, err
 	} else if p.opts.printResponse {
 		prettyPrintResponse(rows, tq)
 	}
-	defer rows.Close()
+	// Fetching all the rows to confirm that the query is fully completed.
+	for rows.Next() {
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	took := float64(time.Since(start).Nanoseconds()) / 1e6
 	stat := query.GetStat()


### PR DESCRIPTION
## Problem

`tsbs_generate_queries` panics with `unimplemented query` for every `cpu-max-all-*` query type with the cratedb and questdb formats.

Upstream PR timescale/tsbs#168 changed the `MaxAllCPU` filler signature to take a `duration time.Duration` parameter and updated most generators, but missed four (cratedb, questdb, akumuli, timestream). Dispatch happens through a type assertion in `cmd/tsbs_generate_queries/uses/devops/max_all_cpu.go`, so the stale 2-arg methods fail the `MaxAllFiller` assertion at runtime instead of breaking the build.


Also submitted upstream as timescale/tsbs#293, but upstream appears unmaintained, merging here so the fork's master is usable

## Verification

`go test -vet=off ./cmd/tsbs_generate_queries/databases/cratedb/ ./cmd/tsbs_generate_queries/databases/questdb/` passes; suite smoke runs include `cpu-max-all-1` end-to-end.