### PR TITLE
Fix CrateDB target issues 

### DIFF
--- a/cmd/tsbs_generate_queries/databases/cratedb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops.go
@@ -128,16 +128,21 @@ func (d *Devops) GroupByOrderByLimit(qi query.Query) {
 
 // LastPointPerHost finds the last row for every host in the dataset
 func (d *Devops) LastPointPerHost(qi query.Query) {
+	metrics := devops.GetAllCPUMetrics()
+	selectClauses := make([]string, len(metrics))
+	for i, m := range metrics {
+		selectClauses[i] = fmt.Sprintf("max_by(%[1]s, ts) AS %[1]s", m)
+	}
+
 	sql := fmt.Sprintf(`
-		SELECT *
-		FROM
-		  (
-			SELECT %[1]s AS host, max(ts) AS max_ts
-			FROM cpu
-			GROUP BY %[1]s
-		  ) t, cpu c
-		WHERE t.max_ts = c.ts
-		  AND t.host = c.%[1]s`, hostnameField)
+		SELECT
+			%s AS host,
+			max(ts) AS max_ts,
+			%s
+		FROM cpu
+		GROUP BY host`,
+		hostnameField,
+		strings.Join(selectClauses, ",\n\t\t\t"))
 
 	humanLabel := "CrateDB last row per host"
 	humanDesc := humanLabel

--- a/cmd/tsbs_generate_queries/databases/cratedb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops.go
@@ -153,8 +153,13 @@ func (d *Devops) LastPointPerHost(qi query.Query) {
 // high-cpu-all
 func (d *Devops) HighCPUForHosts(qi query.Query, nHosts int) {
 	interval := d.Interval.MustRandWindow(devops.HighCPUDuration)
-	hosts, err := d.GetRandomHosts(nHosts)
-	panicIfErr(err)
+
+	var hostWhereClause string
+	if nHosts > 0 {
+		hosts, err := d.GetRandomHosts(nHosts)
+		panicIfErr(err)
+		hostWhereClause = fmt.Sprintf("AND %s IN ('%s')", hostnameField, strings.Join(hosts, "', '"))
+	}
 
 	sql := fmt.Sprintf(`
 		SELECT *
@@ -162,11 +167,10 @@ func (d *Devops) HighCPUForHosts(qi query.Query, nHosts int) {
 		WHERE usage_user > 90.0
 		  AND ts >= %d
 		  AND ts < %d
-		  AND %s IN ('%s')`,
+		  %s`,
 		interval.StartUnixMillis(),
 		interval.EndUnixMillis(),
-		hostnameField,
-		strings.Join(hosts, "', '"))
+		hostWhereClause)
 
 	humanLabel, err := devops.GetHighCPULabel("CrateDB", nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
@@ -170,15 +170,21 @@ func TestDevopsLastPointPerHostQuery(t *testing.T) {
 	want := &query.CrateDB{
 		Table: []byte("cpu"),
 		SqlQuery: []byte(`
-		SELECT *
-		FROM
-		  (
-			SELECT tags['hostname'] AS host, max(ts) AS max_ts
-			FROM cpu
-			GROUP BY tags['hostname']
-		  ) t, cpu c
-		WHERE t.max_ts = c.ts
-		  AND t.host = c.tags['hostname']`),
+		SELECT
+			tags['hostname'] AS host,
+			max(ts) AS max_ts,
+			max_by(usage_user, ts) AS usage_user,
+			max_by(usage_system, ts) AS usage_system,
+			max_by(usage_idle, ts) AS usage_idle,
+			max_by(usage_nice, ts) AS usage_nice,
+			max_by(usage_iowait, ts) AS usage_iowait,
+			max_by(usage_irq, ts) AS usage_irq,
+			max_by(usage_softirq, ts) AS usage_softirq,
+			max_by(usage_steal, ts) AS usage_steal,
+			max_by(usage_guest, ts) AS usage_guest,
+			max_by(usage_guest_nice, ts) AS usage_guest_nice
+		FROM cpu
+		GROUP BY host`),
 	}
 
 	got := &query.CrateDB{}

--- a/cmd/tsbs_load_cratedb/processor.go
+++ b/cmd/tsbs_load_cratedb/processor.go
@@ -3,15 +3,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/jackc/pgx/v4"
 	"github.com/timescale/tsbs/pkg/targets"
-	"strings"
 )
 
 type processor struct {
-	tableDefs map[string]*tableDef
-	connCfg   *pgx.ConnConfig
-	conn      *pgx.Conn
+	tableDefs   map[string]*tableDef
+	connCfg     *pgx.ConnConfig
+	conn        *pgx.Conn
+	insertStmts map[string]string
 }
 
 // load.Processor interface implementation
@@ -25,26 +28,35 @@ func (p *processor) Init(workerNum int, doLoad, _ bool) {
 		panic(err)
 	}
 	p.conn = conn
+	p.insertStmts = map[string]string{}
 }
 
-const InsertStmt = "INSERT INTO %s (%s) VALUES (%s)"
-
-func (p *processor) createInsertStmt(table *tableDef) (string, error) {
-	var cols []string
-	cols = append(cols, "tags", "ts")
-
-	for _, col := range table.cols {
-		cols = append(cols, col)
+// createInsertStmt builds a bulk insert reading one array parameter per
+// column via unnest — CrateDB's recommended bulk-load form over the
+// Postgres wire protocol. Parameter count stays constant regardless of
+// batch size (single-row inserts per batch row are ~an order of magnitude
+// slower and multi-row VALUES hits the 65535 wire-parameter limit at
+// full-profile batch sizes).
+//
+// Parameters carry explicit array casts — CrateDB's type inference for
+// unnest parameters over the wire protocol is unreliable with many columns
+// (it JSON-parses timestamp strings as objects without them).
+//
+//	INSERT INTO t (tags, ts, m1, ...)
+//	  (SELECT * FROM unnest(?::array(object), ?::array(timestamp), ?::array(double precision), ...))
+func (p *processor) createInsertStmt(table *tableDef) string {
+	cols := append([]string{"tags", "ts"}, table.cols...)
+	params := make([]string, 0, len(cols))
+	params = append(params, "?::array(object)", "?::array(timestamp)")
+	for range table.cols {
+		params = append(params, "?::array(double precision)")
 	}
-
-	stmt := fmt.Sprintf(
-		InsertStmt,
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) (SELECT * FROM unnest(%s))",
 		table.fqn(),
 		strings.Join(cols, ","),
-		strings.Repeat(",?", len(cols))[1:],
+		strings.Join(params, ", "),
 	)
-
-	return stmt, nil
 }
 
 // load.Processor interface implementation
@@ -64,22 +76,44 @@ func (p *processor) ProcessBatch(b targets.Batch, doLoad bool) (uint64, uint64) 
 
 // load.Processor interface implementation
 func (p *processor) InsertBatch(table string, rows []*row) uint64 {
+	def := p.tableDefs[table]
+	stmt, ok := p.insertStmts[table]
+	if !ok {
+		stmt = p.createInsertStmt(def)
+		p.insertStmts[table] = stmt
+	}
+
+	// pivot rows into one array per column: tags (JSON strings, implicitly
+	// cast to the object column), timestamps, and one float64 array per metric
+	n := len(rows)
+	tags := make([]string, n)
+	tss := make([]time.Time, n)
+	metrics := make([][]float64, len(def.cols))
+	for i := range metrics {
+		metrics[i] = make([]float64, n)
+	}
+
 	metricCnt := uint64(0)
-	b := pgx.Batch{}
-	for _, row := range rows {
-		insertStmt, err := p.createInsertStmt(p.tableDefs[table])
-		if err != nil {
-			fatal("could not create insert statement for table %s", table)
+	for i, r := range rows {
+		tags[i] = string((*r)[0].([]byte))
+		tss[i] = (*r)[1].(time.Time)
+		for c := range def.cols {
+			metrics[c][i] = (*r)[c+2].(float64)
 		}
-		b.Queue(insertStmt, *row...)
 		// a number of metric values is all row values minus tags and timestamp
 		// this is required by the framework to count the number of inserted
 		// metric values
-		metricCnt += uint64(len(*row) - 2)
+		metricCnt += uint64(len(*r) - 2)
 	}
-	batchResults := p.conn.SendBatch(context.Background(), &b)
-	if err := batchResults.Close(); err != nil {
-		fatal("failed to close a batch operation %v", err)
+
+	args := make([]interface{}, 0, len(def.cols)+2)
+	args = append(args, tags, tss)
+	for _, m := range metrics {
+		args = append(args, m)
+	}
+
+	if _, err := p.conn.Exec(context.Background(), stmt, args...); err != nil {
+		fatal("failed to insert batch into %s: %v", table, err)
 	}
 	return metricCnt
 }

--- a/cmd/tsbs_run_queries_cratedb/main.go
+++ b/cmd/tsbs_run_queries_cratedb/main.go
@@ -63,11 +63,11 @@ func init() {
 }
 
 func main() {
-	processor, err := newProcessor()
-	if err != nil {
-		panic(err)
-	}
 	runner.Run(&query.CrateDBPool, func() query.Processor {
+		processor, err := newProcessor()
+		if err != nil {
+			panic(err)
+		}
 		return processor
 	})
 }

--- a/go.sum
+++ b/go.sum
@@ -828,11 +828,8 @@ github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
-github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
-github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v3.21.3+incompatible h1:uenXGGa8ESCQq+dbgtl916dmg6PSAz2cXov0uORQ9v8=
 github.com/shirou/gopsutil v3.21.3+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc h1:jUIKcSPO9MoMJBbEoyE/RJoE8vz7Mb8AjvifMMwSyvY=
@@ -902,6 +899,7 @@ github.com/timescale/promscale v0.0.0-20201006153045-6a66a36f5c84/go.mod h1:rkhy
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
+github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1136,7 +1134,6 @@ golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200821140526-fda516888d29/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200908134130-d2e65c121b96 h1:gJciq3lOg0eS9fSZJcoHfv7q1BfC6cJfnmSSKL1yu3Q=
 golang.org/x/sys v0.0.0-20200908134130-d2e65c121b96/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa h1:ZYxPR6aca/uhfRJyaOAtflSHjJYiktO7QnJC5ut7iY4=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Summary

This branch bundles several independent CrateDB target fixes discovered while working on the load/query benchmarks:

1. Fix concurrency bug in `tsbs_run_queries_cratedb`

2. `tsbs_load_cratedb` statements replaced with a single `INSERT INTO t (...) (SELECT * FROM unnest(...))` statement per batch, which is recommended bulk-load pattern for CrateDB.

3. `LastPointPerHost` query is replaced a self-join (`SELECT * FROM (SELECT host, max(ts) ...) t, cpu c WHERE t.max_ts = c.ts AND t.host = c.host`) with a single `max_by(metric, ts)` aggregate per metric, grouped by host.

4. `HighCPUForHosts` host filtering honor `nHosts == 0` (all hosts) by making the `AND hostname IN (...)`. previously this path would panic/error when `nHosts` was 0.

5. Drop the stale `gopsutil` v2.18.12 (+ its `shirou/w32` dependency)

## Checklist
- [x] Link to issue this PR refers to (if applicable): Fixes crate/ecosystem/issues/44
